### PR TITLE
Add interactive family tree viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# familytree
+# Family Tree Viewer
+
+This project provides a small web page for interactively exploring a family tree. Nodes representing deceased ancestors are shown in gray while living relatives are shown in white. You can click a person to expand or collapse their descendants.
+
+To try it out, open `index.html` in a web browser.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Family Tree Viewer</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>Interactive Family Tree Viewer</h1>
+<div id="tree"></div>
+
+<script src="https://d3js.org/d3.v7.min.js"></script>
+<script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,135 @@
+const data = {
+  name: "Grandparent",
+  isDeceased: true,
+  children: [
+    {
+      name: "Parent",
+      isDeceased: false,
+      children: [
+        { name: "Child 1", isDeceased: false },
+        { name: "Child 2", isDeceased: false }
+      ]
+    },
+    {
+      name: "Uncle",
+      isDeceased: true,
+      children: [
+        { name: "Cousin", isDeceased: false }
+      ]
+    }
+  ]
+};
+
+const width = 600;
+const dx = 10;
+const dy = width / 4;
+const tree = d3.tree().nodeSize([dx, dy]);
+const diagonal = d3.linkHorizontal().x(d => d.y).y(d => d.x);
+
+const root = d3.hierarchy(data);
+root.x0 = dy / 2;
+root.y0 = 0;
+root.descendants().forEach((d, i) => {
+  d.id = i;
+  d._children = d.children;
+});
+
+const svg = d3.select("#tree").append("svg")
+    .attr("viewBox", [-dy / 3, -dx, width, dx * 10])
+    .style("font", "10px sans-serif")
+    .style("user-select", "none");
+
+const gLink = svg.append("g")
+    .attr("class", "links")
+    .attr("fill", "none")
+    .attr("stroke", "#555")
+    .attr("stroke-opacity", 0.4)
+    .attr("stroke-width", 1.5);
+
+const gNode = svg.append("g")
+    .attr("class", "nodes")
+    .attr("cursor", "pointer")
+    .attr("pointer-events", "all");
+
+function update(source) {
+  const nodes = root.descendants().reverse();
+  const links = root.links();
+
+  tree(root);
+
+  let left = root;
+  let right = root;
+  root.eachBefore(node => {
+    if (node.x < left.x) left = node;
+    if (node.x > right.x) right = node;
+  });
+
+  const height = right.x - left.x + dx * 2;
+
+  const transition = svg.transition()
+      .duration(250)
+      .attr("viewBox", [-dy / 3, left.x - dx, width, height]);
+
+  const node = gNode.selectAll("g")
+    .data(nodes, d => d.id);
+
+  const nodeEnter = node.enter().append("g")
+      .attr("transform", d => `translate(${source.y0},${source.x0})`)
+      .on("click", (event, d) => {
+          d.children = d.children ? null : d._children;
+          update(d);
+      });
+
+  nodeEnter.append("circle")
+      .attr("r", 4)
+      .attr("fill", d => d.data.isDeceased ? "#999" : "#fff")
+      .attr("stroke", "#555");
+
+  nodeEnter.append("text")
+      .attr("dy", "0.31em")
+      .attr("x", d => d._children ? -6 : 6)
+      .attr("text-anchor", d => d._children ? "end" : "start")
+      .text(d => d.data.name)
+      .clone(true).lower()
+      .attr("stroke", "white");
+
+  node.merge(nodeEnter).transition(transition)
+      .attr("transform", d => `translate(${d.y},${d.x})`);
+
+  node.merge(nodeEnter).select("circle")
+      .attr("fill", d => d.data.isDeceased ? "#999" : "#fff");
+
+  node.merge(nodeEnter).select("text")
+      .attr("x", d => d._children ? -6 : 6)
+      .attr("text-anchor", d => d._children ? "end" : "start");
+
+  node.exit().transition(transition).remove()
+      .attr("transform", d => `translate(${source.y},${source.x})`)
+      .select("circle")
+      .attr("r", 0);
+
+  const link = gLink.selectAll("path")
+    .data(links, d => d.target.id);
+
+  const linkEnter = link.enter().append("path")
+      .attr("d", d => {
+          const o = {x: source.x0, y: source.y0};
+          return diagonal({source: o, target: o});
+      });
+
+  link.merge(linkEnter).transition(transition)
+      .attr("d", diagonal);
+
+  link.exit().transition(transition).remove()
+      .attr("d", d => {
+          const o = {x: source.x, y: source.y};
+          return diagonal({source: o, target: o});
+      });
+
+  root.eachBefore(d => {
+      d.x0 = d.x;
+      d.y0 = d.y;
+  });
+}
+
+update(root);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,27 @@
+body {
+    font-family: Arial, sans-serif;
+}
+
+#tree {
+    margin-top: 20px;
+}
+
+.node circle {
+    fill: #fff;
+    stroke: #555;
+    stroke-width: 1.5px;
+}
+
+.node text {
+    font: 12px sans-serif;
+}
+
+.node.deceased circle {
+    fill: #999;
+}
+
+.link {
+    fill: none;
+    stroke: #555;
+    stroke-width: 1.5px;
+}


### PR DESCRIPTION
## Summary
- add a simple web-based viewer for exploring a family tree
- style nodes to show whether a relative is deceased or living
- describe usage in README

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6868d665a25483228d96b0da437d7191